### PR TITLE
Improve `link_externals` method a bit

### DIFF
--- a/parse_at_target/src/main.rs
+++ b/parse_at_target/src/main.rs
@@ -28,7 +28,8 @@ fn main() -> Result<()> {
     };
 
     // from here on, both option do the same
-    let (externals, mut store) = link_externals(&module, &engine)?;
+    let mut externals = Vec::new();
+    let mut store = link_externals(&module, &engine, &mut externals)?;
     let started = Instance::new(&mut store, &module, &externals)?;
 
     println!("First call");

--- a/run_preparsed/src/main.rs
+++ b/run_preparsed/src/main.rs
@@ -16,7 +16,8 @@ fn main() -> Result<()> {
         deserialize_module(&preparsed_bytes).map_err(|e| anyhow!("failed to deser module: {e}"))?;
 
     // from here on, both option do the same
-    let (externals, mut store) = link_externals(&module, &engine)?;
+    let mut externals = Vec::new();
+    let mut store = link_externals(&module, &engine, &mut externals)?;
     let started = Instance::new(&mut store, &module, &externals)?;
 
     println!("First call");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,90 +5,69 @@ mod state;
 
 use anyhow::{Result, bail};
 pub use state::ModuleState;
-use wasmi::{AsContext, Caller, Engine, Extern, Func, FuncType, Module, Store};
+use wasmi::{AsContext, Caller, Engine, Extern, Func, Module, Store};
 
 const MODULE_FUEL: u64 = 1000;
 
 pub fn link_externals(
     module: &Module,
     engine: &Engine,
-) -> Result<(Vec<Extern>, Store<ModuleState>)> {
-    let state = ModuleState::default();
-    let mut store = Store::new(engine, state);
+    externals: &mut Vec<Extern>,
+) -> Result<Store<ModuleState>> {
+    let mut store = Store::new(engine, ModuleState::default());
     store.set_fuel(MODULE_FUEL)?;
-
-    let module_imports = module.imports();
-    let mut externals = Vec::with_capacity(module_imports.len());
-
-    for import in module_imports {
+    let imports = module.imports();
+    externals.clear();
+    externals.reserve(imports.len());
+    for import in imports {
         let module_name = import.module();
         let field_name = import.name();
-        let ty = import.ty();
-
-        match ty {
-            wasmi::ExternType::Func(func_ty) => {
-                let host_func_ty =
-                    FuncType::new(func_ty.params().to_vec(), func_ty.results().to_vec());
-
-                let host_func = match (module_name, field_name) {
-                    ("env", "init_led") => Func::new(
-                        &mut store,
-                        host_func_ty,
-                        move |mut caller: Caller<'_, ModuleState>, _args, _results| {
-                            if caller.data().initialized {
-                                println!("led already initialized");
-                            } else {
-                                caller.data_mut().initialized = true;
-                                println!("led initialized now");
-                            }
-                            Ok(())
-                        },
-                    ),
-
-                    ("env", "set_led") => Func::new(
-                        &mut store,
-                        host_func_ty,
-                        move |mut caller: Caller<'_, ModuleState>, args, _results| {
-                            let led_on = args[0].i32().expect("led_on has to be an int");
-                            caller.data_mut().set_led(led_on == 1);
-                            Ok(())
-                        },
-                    ),
-
-                    ("logging", "log") => Func::new(
-                        &mut store,
-                        host_func_ty,
-                        move |caller: Caller<'_, ModuleState>, args, _results| {
-                            let buffer_ptr = args[0].i32().expect("buffer ptr has to be an int");
-                            let length = args[1].i32().expect("buffer len has to be an int");
-
-                            let memory = caller
-                                .get_export("memory")
-                                .expect("module does not export memory")
-                                .into_memory()
-                                .expect("failed to get memory");
-                            let store = caller.as_context();
-                            let data_start = buffer_ptr as usize;
-                            let data_end = data_start + (length as usize);
-                            let data = &memory.data(&store)[data_start..data_end];
-
-                            let log_msg = str::from_utf8(data).expect("failed to convert string");
-                            println!("module log: {log_msg}");
-                            Ok(())
-                        },
-                    ),
-
-                    (unknown_module, unknown_field) => bail!(
-                        "unexpected function import: module {unknown_module}, name: {unknown_field}"
-                    ),
-                };
-
-                externals.push(Extern::Func(host_func));
+        let host_func = match (module_name, field_name) {
+            ("env", "init_led") => {
+                Func::wrap(
+                    &mut store,
+                    move |mut caller: Caller<'_, ModuleState>| -> Result<(), wasmi::Error> {
+                        if caller.data().initialized {
+                            println!("led already initialized");
+                        } else {
+                            caller.data_mut().initialized = true;
+                            println!("led initialized now");
+                        }
+                        Ok(())
+                    },
+                )
             }
-
-            _ => bail!("unexpected import (not a function)"), // just for the small example
-        }
+            ("env", "set_led") => {
+                Func::wrap(
+                    &mut store,
+                    move |mut caller: Caller<'_, ModuleState>, led_on: i32| {
+                        caller.data_mut().set_led(led_on == 1);
+                        Ok(())
+                    },
+                )
+            }
+            ("logging", "log") => {
+                Func::wrap(
+                    &mut store,
+                    move |caller: Caller<'_, ModuleState>, buffer_ptr: i32, length: i32| {
+                        let memory = caller
+                            .get_export("memory")
+                            .expect("module does not export memory")
+                            .into_memory()
+                            .expect("failed to get memory");
+                        let store = caller.as_context();
+                        let data_start = buffer_ptr as usize;
+                        let data_end = data_start + (length as usize);
+                        let data = &memory.data(&store)[data_start..data_end];
+                        let log_msg = str::from_utf8(data).expect("failed to convert string");
+                        println!("module log: {log_msg}");
+                        Ok(())
+                    },
+                )
+            }
+            _ => bail!("unknown import at: {module_name}::{field_name}"),
+        };
+        externals.push(Extern::Func(host_func));
     }
-
-    Ok((externals, store))
+    Ok(store)
 }


### PR DESCRIPTION
As requested in https://github.com/wasmi-labs/wasmi/issues/1637#issuecomment-3197720953.

cc @FedorSmirnov89 

- The `externals: &mut Vec<Extern>` allows for potential memory reuse between runs if applicable. Generally one should avoid returning `Vec` and instead take `&mut Vec` and adjust it, just as with C buffers.
- No longer constructs a `FuncType`.
- Uses the more efficient `Func::wrap` instead of `Func::new`.
- Lets `Instance::new` do the type checking.

I really hope you removed all `println` and `bail` macro invokations when benchmarking this for binary size and runtime performance. Those really dent both metrics.